### PR TITLE
Fix: Using Non-Default Region in S3

### DIFF
--- a/config.js
+++ b/config.js
@@ -15,7 +15,10 @@ module.exports = {
     tarballTTL: parseInt(env.CACHE_TARBALL_TTL) || (6 * 60 * 60)
   },
   fs: {directory: env.NPM_REGISTER_FS_DIRECTORY || 'tmp'},
-  s3: {bucket: env.AWS_S3_BUCKET}
+  s3: {
+    bucket: env.AWS_S3_BUCKET,
+    region: env.AWS_DEFAULT_REGION
+  }
 }
 
 let Storage = require('./lib/storage/' + (env.NPM_REGISTER_STORAGE || 'fs'))

--- a/lib/storage/s3.js
+++ b/lib/storage/s3.js
@@ -4,50 +4,51 @@ const AWS = require('aws-sdk')
 const config = require('../../config')
 const Promise = require('bluebird')
 const Stream = require('stream')
+AWS.config.region = config.s3.region
 
 class S3 extends require('./base') {
   constructor () {
     super()
     this.client = Promise.promisifyAll(require('s3').createClient({
-      s3Client: Promise.promisifyAll(new AWS.S3())
+      s3Client: Promise.promisifyAll(new AWS.S3({ params: { Bucket: config.s3.bucket } }))
     }))
     console.error(`Saving files to s3 bucket ${config.s3.bucket}`)
   }
 
-  get (key) {
+  get (Key) {
     return new Promise((resolve, reject) => {
-      this.client.downloadBuffer(this._params(key))
+      this.client.downloadBuffer({ Key })
       .on('error', () => resolve())
       .on('end', resolve)
     })
   }
 
-  put (key, data) {
-    let params = this._params(key)
+  put (Key, data) {
+    let params = { Key }
     if (data instanceof Stream || data instanceof Buffer) {
       params.Body = data
     } else if (data instanceof Object) {
       params.Body = JSON.stringify(data)
       params.ContentType = 'application/json'
     }
-    console.log(`Uploading ${key} to s3`)
+    console.log(`Uploading ${Key} to s3`)
     return this.client.s3.uploadAsync(params)
   }
 
-  stream (key) {
-    console.log(`Fetching ${key} from s3`)
-    return this.client.s3.headObjectAsync(this._params(key))
+  stream (Key) {
+    console.log(`Fetching ${Key} from s3`)
+    return this.client.s3.headObjectAsync({ Key })
     .then(obj => {
       return {
         size: obj.ContentLength,
-        stream: this.client.downloadStream(this._params(key))
+        stream: this.client.downloadStream({ Key })
       }
     })
     .catch(err => { if (err.code !== 'NotFound') throw err })
   }
 
-  delete (key) {
-    return this.client.s3.deleteObjectAsync(this._params(key))
+  delete (Key) {
+    return this.client.s3.deleteObjectAsync({ Key })
   }
 
   list (prefix) {
@@ -57,13 +58,6 @@ class S3 extends require('./base') {
     }).then(dirs => {
       return dirs.Contents.map(c => c.Key)
     })
-  }
-
-  _params (key, opts) {
-    return Object.assign({
-      Bucket: config.s3.bucket,
-      Key: key
-    }, opts)
   }
 }
 


### PR DESCRIPTION
This PR adds support for the `AWS_DEFAULT_REGION` environment variable. That functionality is needed whenever your AWS region is not `'us-east-1'`. It also removes the `S3#_params` method and instead sets `Bucket` as a default parameter in the instantiation of `AWS.S3`.