### PR TITLE
Allow npm-register to work with Docker signals

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,5 +35,5 @@ VOLUME /data
 EXPOSE 3000
 USER register
 ENV NODE_ENV production
-CMD ["npm", "start"]
+CMD ["node", "start.js"]
 

--- a/start.js
+++ b/start.js
@@ -3,3 +3,13 @@ const app = require('./server')
 app.listen(app.port, function () {
   console.error(`${app.name} listening on port ${app.port} [${app.env}]`)
 })
+
+
+process.on('SIGINT', function(){
+  console.info('Recieved SIGINT, exiting')
+  process.exit(0)
+})
+process.on('SIGTERM', function(){
+  console.log('Recieved SIGTERM, exiting')
+  process.exit(0)
+})


### PR DESCRIPTION
Docker requires signal handlers to be installed in the PID1 process of the container for those signals to be handled.

Add the handlers and remove the `npm` shim. 