### PR TITLE
Handle accidental uppercase values

### DIFF
--- a/config.js
+++ b/config.js
@@ -21,5 +21,5 @@ module.exports = {
   }
 }
 
-let Storage = require('./lib/storage/' + (env.NPM_REGISTER_STORAGE || 'fs'))
+let Storage = require('./lib/storage/' + (env.NPM_REGISTER_STORAGE.toLowerCase() || 'fs'))
 module.exports.storage = new Storage()


### PR DESCRIPTION
If `NPM_REGISTER_STORAGE` is set to an uppercase `S3` value then the app will bomb out with a non-descriptive error message. I scratched my head on this for about 15 minutes before I figured this out. Therefore, I figured I would contribute a small fix to help make this app more user-friendly.
