### PR TITLE
make unpublished packages return 404

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -45,6 +45,7 @@ function * get (name, etag) {
     if (etag) opts.headers['if-none-match'] = etag
     let res = yield got(url.resolve(config.uplink.href, '/' + name.replace(/\//, '%2F')), opts)
     pkg = JSON.parse(res.body)
+    if (!pkg.versions) return 404
     pkg.etag = res.headers.etag
     updateCache(pkg)
     return pkg


### PR DESCRIPTION
unpublished packages return objects like this:

```js
{ _id: 'salesforce-alm',
  _rev: '3-33501e8dcd1f5aff5cc4e2e5156b8de0',
  name: 'salesforce-alm',
  time:
   { modified: '2016-12-07T16:28:02.949Z',
     created: '2016-12-07T13:50:24.788Z',
     '0.6.22': '2016-12-07T13:50:24.788Z',
     '0.6.23': '2016-12-07T13:52:31.994Z',
     unpublished:
      { name: 'cisfuser1',
        time: '2016-12-07T16:28:02.949Z',
        tags: [Object],
        maintainers: [Object],
        versions: [Object] } },
  _attachments: {} }
```