### PR TITLE
Add --always-https flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,10 @@ This stores the credentials in `~/.npmrc`. You can now use `npm publish` to publ
 ### Configuration via environment variables
 
 By default, all write endpoints (e.g. publish, unpublish) require authentication whereas read endpoints (e.g. install) don't. This default behaviour can be changed by using `NPM_REGISTER_AUTH_WRITE` and `NPM_REGISTER_AUTH_READ` environment variables: use `true` to enable authentication and `false` to disable it.
+
+Yarn compatibility
+------------------
+
+Yarn doesn't follow HTTP redirects and so expects all URLs to be HTTPS by default. Pass
+`--always-https` to ignore the protocol header and return all responses in a format Yarn
+understands.

--- a/bin/npm-register
+++ b/bin/npm-register
@@ -3,6 +3,8 @@
 
 const argv = require('yargs')
   .command('start', 'start the server')
+  .boolean('always-https')
+  .describe('always-https', 'Ingore request headers and always return HTTPS URLs')
   .demand(1)
   .strict()
   .help('h')

--- a/routes/packages.js
+++ b/routes/packages.js
@@ -6,6 +6,7 @@ const url = require('url')
 const packages = require('../lib/packages')
 const config = require('../config')
 const middleware = require('../middleware')
+const argv = require('yargs').argv;
 
 function addShaToPath (p, sha) {
   let ext = path.extname(p)
@@ -17,6 +18,10 @@ function addShaToPath (p, sha) {
 }
 
 function rewriteTarballURLs (pkg, host, protocol) {
+  if (argv.alwaysHttps) {
+    protocol = 'https'
+  }
+
   for (let version of Object.keys(pkg.versions)) {
     let dist = pkg.versions[version].dist
     let u = url.parse(dist.tarball)


### PR DESCRIPTION
This allows npm-register to work with Yarn, which expects all tarball URLs to be HTTPS by default, and will not follow redirects from HTTP URLs. Let me know if you have any questions. Thanks!