### PR TITLE
feat(routes): implement NPM_REGISTER_URL_PREFIX

### DIFF
--- a/config.js
+++ b/config.js
@@ -25,7 +25,8 @@ module.exports = {
   },
   httpProxyHost: env.HTTP_PROXY_HOST,
   httpProxyPort: env.HTTP_PROXY_PORT,
-  httpProxyAuth: env.HTTP_PROXY_AUTH
+  httpProxyAuth: env.HTTP_PROXY_AUTH,
+  urlPrefix: env.NPM_REGISTER_URL_PREFIX
 }
 
 let storageType = ((env.NPM_REGISTER_STORAGE && env.NPM_REGISTER_STORAGE.toLowerCase()) || 'fs')

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const r = require('koa-router')()
+const config = require('../config')
+const r = require('koa-router')({ prefix: config.urlPrefix })
 const sendfile = require('koa-sendfile')
 const path = require('path')
 


### PR DESCRIPTION
In my use-case `npm-register` is running behind a layer 7 loadbalancer. It only routes traffic to `npm-register` on a specific path. This PR implements a configuration option for that.